### PR TITLE
21 Added in stats file for outputs

### DIFF
--- a/input.json
+++ b/input.json
@@ -1,7 +1,7 @@
 {
-  "jgi_metaAssembly.input_files":["https://data.microbiomedata.org/data/test_data/11809.7.220839.TCCTGAG-ACTGCAT.fastq.gz"],
+  "jgi_metaAssembly.input_files":["/global/cfs/cdirs/m3408/www/test_data/SRR13128014.pacbio.subsample.ccs.fastq.gz"],
   "jgi_metaAssembly.proj":"nmdc:503125_160870",
   "jgi_metaAssembly.memory": "105G",
   "jgi_metaAssembly.threads": "16",
-  "jgi_metaAssembly.shortRead": true
+  "jgi_metaAssembly.shortRead": false
 }

--- a/jgi_assembly.wdl
+++ b/jgi_assembly.wdl
@@ -30,7 +30,7 @@ workflow jgi_metaAssembly {
         	call int.make_interleaved_reads {
 			input:
 			input_files = input_files,
-            container = bbtools_container
+            container = "microbiomedata/bbtools:38.96"
        		}
     	}
         call srma.jgi_metaASM {
@@ -39,7 +39,7 @@ workflow jgi_metaAssembly {
             threads = threads,
             input_file = if length(input_files) > 1 then make_interleaved_reads.interleaved_fastq else input_files[0],
             proj = proj,
-            bbtools_container = bbtools_container
+            bbtools_container = "microbiomedata/bbtools:38.96"
 
         }
         

--- a/jgi_assembly.wdl
+++ b/jgi_assembly.wdl
@@ -21,7 +21,7 @@ workflow jgi_metaAssembly {
         String minimap2_container = "staphb/minimap2:2.25"
         String minimap2_parameters = "-a -x map-hifi -t 32"
         String samtools_container = "staphb/samtools:1.18"
-        String bbtools_container = "microbiomedata/bbtools:38.96"
+        String bbtools_container = "microbiomedata/bbtools:39.03"
     }
 
 

--- a/jgi_assembly.wdl
+++ b/jgi_assembly.wdl
@@ -1,10 +1,10 @@
 version 1.0
 import "shortReads_assembly.wdl" as srma
 import "make_interleaved_WDL/make_interleaved_reads.wdl" as int
-# import "jgi_meta_wdl/metagenome_improved/metaflye.wdl" as lrma
-import "https://code.jgi.doe.gov/BFoster/jgi_meta_wdl/-/raw/bc7c4371ea0fa83355bada341ec353b9feb3eff2/metagenome_improved/metaflye.wdl" as lrma
+import "jgi_meta_wdl/metagenome_improved/metaflye.wdl" as lrma
+# import "https://code.jgi.doe.gov/BFoster/jgi_meta_wdl/-/raw/bc7c4371ea0fa83355bada341ec353b9feb3eff2/metagenome_improved/metaflye.wdl" as lrma
 
-workflow jgi_metaAssembly{
+workflow jgi_metaAssembly {
     input {  
         Boolean shortRead
         String proj
@@ -26,14 +26,14 @@ workflow jgi_metaAssembly{
 
 
     if (shortRead) {
-    	if (length(input_files) > 1){
-        	call int.make_interleaved_reads{
+    	if (length(input_files) > 1) {
+        	call int.make_interleaved_reads {
 			input:
 			input_files = input_files,
             container = bbtools_container
        		}
     	}
-        call srma.jgi_metaASM{
+        call srma.jgi_metaASM {
             input:
             memory = memory,
             threads = threads,
@@ -45,7 +45,7 @@ workflow jgi_metaAssembly{
         
     }
     if (!shortRead) {
-        call lrma.metaflye{
+        call lrma.metaflye {
             input:
             proj = proj,
             input_fastq = input_files,
@@ -58,7 +58,7 @@ workflow jgi_metaAssembly{
             samtools_container = samtools_container,
             bbtools_container = bbtools_container
         }
-        call finish_lrasm{
+        call finish_lrasm {
             input: 
             proj = proj,
             prefix = prefix,
@@ -98,33 +98,34 @@ workflow jgi_metaAssembly{
         File? sr_bam=jgi_metaASM.bam
         File? sr_samgz=jgi_metaASM.samgz
         File? sr_covstats=jgi_metaASM.covstats
-        File? sr_asmstats=jgi_metaASM.asmstats
         File? sr_asminfo=jgi_metaASM.asminfo
         File? sr_bbcms_fq = jgi_metaASM.bbcms_fastq
-          
+
+        #Both
+        File? stats = if (shortRead) then jgi_metaASM.asmstats else metaflye.asmstats
     }
 }
 
 
 task finish_lrasm {
     input {
-    File contigs
-    File bam
-    File scaffolds
-    File agp
-    File legend
-    File basecov
-    File sam
-    File output_file
-    File stats
-    File summary_stats
-    File pileup_out
-    String container
-    String proj
-    String prefix 
-    String orig_prefix="scaffold"
-    String sed="s/~{orig_prefix}_/~{proj}_/g"
-    # String start
+        File contigs
+        File bam
+        File scaffolds
+        File agp
+        File legend
+        File basecov
+        File sam
+        File output_file
+        File stats
+        File summary_stats
+        File pileup_out
+        String container
+        String proj
+        String prefix 
+        String orig_prefix="scaffold"
+        String sed="s/~{orig_prefix}_/~{proj}_/g"
+        # String start
     }
     command<<<
 

--- a/shortReads_assembly.wdl
+++ b/shortReads_assembly.wdl
@@ -10,10 +10,10 @@ workflow jgi_metaASM {
         String rename_contig_prefix="scaffold"
         # Float uniquekmer=1000
         String bbtools_container="microbiomedata/bbtools:38.96"
-        String spades_container="microbiomedata/spades:3.15.0"
+        String spades_container="staphb/spades:4.0.0"
         String workflowmeta_container="microbiomedata/workflowmeta:1.1.1"
         Boolean paired = true
-    }
+        }
 
     call stage {
         input:
@@ -117,51 +117,50 @@ workflow jgi_metaASM {
 }
 
 task stage {
-    input { 
-        String container
-        String? input_file
-        String memory = "4G"
-        String target = "staged.fastq.gz"
-        String output1 = "input.left.fastq.gz"
-        String output2 = "input.right.fastq.gz"
-    }
+   input { 
+   String container
+   String? input_file
+   String memory = "4G"
+   String target = "staged.fastq.gz"
+   String output1 = "input.left.fastq.gz"
+   String output2 = "input.right.fastq.gz"
+   }
 
-    command<<<
-
-        set -euo pipefail
-        if [ $( echo ~{input_file}|egrep -c "https*:") -gt 0 ] ; then
-            wget ~{input_file} -O ~{target}
-        else
-            ln -s ~{input_file} ~{target} || cp ~{input_file} ~{target}
-        fi
+   command <<<
+       set -euo pipefail
+       if [ $( echo ~{input_file}|egrep -c "https*:") -gt 0 ] ; then
+           wget ~{input_file} -O ~{target}
+       else
+           ln -s ~{input_file} ~{target} || cp ~{input_file} ~{target}
+       fi
 
         reformat.sh \
         ~{if (defined(memory)) then "-Xmx" + memory else "-Xmx10G" }\
         in=~{target} \
         out1=~{output1} \
         out2=~{output2}    
-        # Capture the start time
-        date --iso-8601=seconds > start.txt
+       # Capture the start time
+       date --iso-8601=seconds > start.txt
 
-    >>>
+   >>>
 
-    output {
-        Array[File] assembly_input = [output1, output2]
-        String start = read_string("start.txt")
-    }
-    runtime {
-        cpu:  2
-        maxRetries: 1
-        docker: container
-    }
+   output {
+      Array[File] assembly_input = [output1, output2]
+      String start = read_string("start.txt")
+   }
+   runtime {
+     cpu:  2
+     maxRetries: 1
+     docker: container
+   }
 }
 
 task make_info_file {
-    input {
-        File assy_info
-        File bbcms_info
-        String prefix
-        String container
+    input{
+    File assy_info
+    File bbcms_info
+    String prefix
+    String container
     }
 
     command<<<
@@ -180,7 +179,6 @@ task make_info_file {
     output {
         File asminfo = "~{prefix}_metaAsm.info"
     }
-
     runtime {
         memory: "1 GiB"
         cpu:  1
@@ -191,20 +189,20 @@ task make_info_file {
 
 task finish_asm {
     input {
-        File fasta
-        File scaffold
-        File? agp
-        File bam
-        File? samgz
-        File? covstats
-        File asmstats
-        File bbcms_fastq
-        String container
-        String proj
-        String prefix 
-        String orig_prefix="scaffold"
-        String sed="s/~{orig_prefix}_/~{proj}_/g"
-        # String start
+    File fasta
+    File scaffold
+    File? agp
+    File bam
+    File? samgz
+    File? covstats
+    File asmstats
+    File bbcms_fastq
+    String container
+    String proj
+    String prefix 
+    String orig_prefix="scaffold"
+    String sed="s/~{orig_prefix}_/~{proj}_/g"
+    # String start
     }
 
     command<<<
@@ -253,28 +251,32 @@ task finish_asm {
 }
 
 
-task read_mapping_pairs {
+task read_mapping_pairs{
     input {
-        Array[File] reads
-        File ref
-        String container
-        String? memory
-        String? threads
-        Boolean paired = true
-        String bbmap_interleaved_flag = if paired then 'interleaved=true' else 'interleaved=false'
+    Array[File] reads
+    File ref
+    String container
+    String? memory
+    String? threads
+    Boolean paired = true
+    String bbmap_interleaved_flag = if paired then 'interleaved=true' else 'interleaved=false'
 
-        String filename_unsorted="pairedMapped.bam"
-        String filename_outsam="pairedMapped.sam.gz"
-        String filename_sorted="pairedMapped_sorted.bam"
-        String filename_sorted_idx="pairedMapped_sorted.bam.bai"
-        String filename_bamscript="to_bam.sh"
-        String filename_cov="covstats.txt"
-        String system_cpu="$(grep \"model name\" /proc/cpuinfo | wc -l)"
-        String jvm_threads=select_first([threads,system_cpu])
+    String filename_unsorted="pairedMapped.bam"
+    String filename_outsam="pairedMapped.sam.gz"
+    String filename_sorted="pairedMapped_sorted.bam"
+    String filename_sorted_idx="pairedMapped_sorted.bam.bai"
+    String filename_bamscript="to_bam.sh"
+    String filename_cov="covstats.txt"
+    String system_cpu="$(grep \"model name\" /proc/cpuinfo | wc -l)"
+    String jvm_threads=select_first([threads,system_cpu])
     }
-
+    runtime {
+            docker: container
+            memory: "120 GiB"
+        cpu:  16
+        maxRetries: 1
+     }
     command<<<
-
         set -euo pipefail
         if [[ ~{reads[0]}  == *.gz ]] ; then
              cat ~{sep=" " reads} > infile.fastq.gz
@@ -317,32 +319,30 @@ task read_mapping_pairs {
 
     >>>
     output {
-        File outbamfile = filename_sorted
-        File outbamfileidx = filename_sorted_idx
-        File outcovfile = filename_cov
-        File outsamfile = filename_outsam
-    }
-    runtime {
-        docker: container
-        memory: "120 GiB"
-        cpu:  16
-        maxRetries: 1
-    }
+      File outbamfile = filename_sorted
+      File outbamfileidx = filename_sorted_idx
+      File outcovfile = filename_cov
+      File outsamfile = filename_outsam
+  }
 }
 
 task create_agp {
     input {
-        File scaffolds_in
-        String? memory
-        String container
-        String rename_contig_prefix
-        String prefix="assembly"
-        String filename_contigs="~{prefix}_contigs.fna"
-        String filename_scaffolds="~{prefix}_scaffolds.fna"
-        String filename_agp="~{prefix}.agp"
-        String filename_legend="~{prefix}_scaffolds.legend"
+    File scaffolds_in
+    String? memory
+    String container
+    String rename_contig_prefix
+    String prefix="assembly"
+    String filename_contigs="~{prefix}_contigs.fna"
+    String filename_scaffolds="~{prefix}_scaffolds.fna"
+    String filename_agp="~{prefix}.agp"
+    String filename_legend="~{prefix}_scaffolds.legend"
     }
-
+    runtime {
+            docker: container
+            memory: "120 GiB"
+        cpu:  16
+     }
     command<<<
         set -euo pipefail
         fungalrelease.sh \
@@ -368,35 +368,33 @@ task create_agp {
     >>>
 
     output {
-        File outcontigs = filename_contigs
-        File outscaffolds = filename_scaffolds
-        File outagp = filename_agp
-        File outstats = "stats.json"
-        File outlegend = filename_legend
-    }
-
-    runtime {
-        docker: container
-        memory: "120 GiB"
-        cpu:  16
+    File outcontigs = filename_contigs
+    File outscaffolds = filename_scaffolds
+    File outagp = filename_agp
+    File outstats = "stats.json"
+    File outlegend = filename_legend
     }
 }
 
 task assy {
-    input {
-        File infile1
-        File infile2
-        String container
-        String? threads
-        String outprefix="spades3"
-        String filename_outfile="~{outprefix}/scaffolds.fasta"
-        String filename_spadeslog ="~{outprefix}/spades.log"
-        String system_cpu="$(grep \"model name\" /proc/cpuinfo | wc -l)"
-        String spades_cpu=select_first([threads,system_cpu])
-        Boolean paired = true
+    input{
+     File infile1
+     File infile2
+     String container
+     String? threads
+     String outprefix="spades3"
+     String filename_outfile="~{outprefix}/scaffolds.fasta"
+     String filename_spadeslog ="~{outprefix}/spades.log"
+     String system_cpu="$(grep \"model name\" /proc/cpuinfo | wc -l)"
+     String spades_cpu=select_first([threads,system_cpu])
+     Boolean paired = true
     }
-
-    command <<<
+     runtime {
+        docker: container
+        memory: "120 GiB"
+        cpu:  16
+     }
+     command <<<
         set -euo pipefail
         if ~{paired}; then
             spades.py \
@@ -419,43 +417,43 @@ task assy {
         fi
     >>>
 
-    output {
-        File out = filename_outfile
-        File outlog = filename_spadeslog
-    }
-    runtime {
-        docker: container
-        memory: "120 GiB"
-        cpu:  16
-    }
+     output {
+            File out = filename_outfile
+            File outlog = filename_spadeslog
+     }
 }
 
 task bbcms {
-    input {
-        Array[File] input_files
-        String container
-        String? memory
-        Boolean paired = true
-        String filename_outfile="input.corr.fastq.gz"
-        String filename_outfile1="input.corr.left.fastq.gz"
-        String filename_outfile2="input.corr.right.fastq.gz"
-        String filename_readlen="readlen.txt"
-        String filename_outlog="stdout.log"
-        String filename_errlog="stderr.log"
-        String filename_kmerfile="unique31mer.txt"
-        String filename_counts="counts.metadata.json"
+    input{
+     Array[File] input_files
+     String container
+     String? memory
+     Boolean paired = true
+     String filename_outfile="input.corr.fastq.gz"
+     String filename_outfile1="input.corr.left.fastq.gz"
+     String filename_outfile2="input.corr.right.fastq.gz"
+     String filename_readlen="readlen.txt"
+     String filename_outlog="stdout.log"
+     String filename_errlog="stderr.log"
+     String filename_kmerfile="unique31mer.txt"
+     String filename_counts="counts.metadata.json"
     }
+     runtime {
+        docker: container
+        memory: "120 GiB"
+        cpu:  16
+     }
 
     command<<<
         set -euo pipefail
         if file --mime -b ~{input_files[0]} | grep gzip; then
-                cat ~{sep=" " input_files} > infile.fastq.gz
-                export bbcms_input="infile.fastq.gz"
+             cat ~{sep=" " input_files} > infile.fastq.gz
+             export bbcms_input="infile.fastq.gz"
         fi
 
         if file --mime -b ~{input_files[0]} | grep plain; then
-                cat ~{sep=" " input_files} > infile.fastq
-                export bbcms_input="infile.fastq"
+             cat ~{sep=" " input_files} > infile.fastq
+             export bbcms_input="infile.fastq"
         fi
 
         bbcms.sh \
@@ -485,24 +483,20 @@ task bbcms {
         out=~{filename_readlen}
 
         rm $bbcms_input
-    
+        
     >>>
 
-    output {
-        File out = filename_outfile
-        File out1 = if paired then filename_outfile1 else filename_outfile
-        File out2 = if paired then filename_outfile2 else filename_outfile
-        File outreadlen = filename_readlen
-        File stdout = filename_outlog
-        File stderr = filename_errlog
-        File outcounts = filename_counts
-        File outkmer = filename_kmerfile
-    }
-    runtime {
-        docker: container
-        memory: "120 GiB"
-        cpu:  16
-    }
+     output {
+            File out = filename_outfile
+            File out1 = if paired then filename_outfile1 else filename_outfile
+            File out2 = if paired then filename_outfile2 else filename_outfile
+            File outreadlen = filename_readlen
+            File stdout = filename_outlog
+            File stderr = filename_errlog
+            File outcounts = filename_counts
+            File outkmer = filename_kmerfile
+            
+     }
 }
 
 # task make_output{
@@ -547,4 +541,3 @@ task bbcms {
 #         File? outasmstats = "~{outdir}/~{asmstats_name}"
 #     }
 # }
-

--- a/shortReads_assembly.wdl
+++ b/shortReads_assembly.wdl
@@ -11,7 +11,7 @@ workflow jgi_metaASM {
         # Float uniquekmer=1000
         String bbtools_container="microbiomedata/bbtools:38.96"
         String spades_container="microbiomedata/spades:3.15.0"
-        String worflowmeta_container="microbiomedata/workflowmeta:1.1.1"
+        String workflowmeta_container="microbiomedata/workflowmeta:1.1.1"
         Boolean paired = true
     }
 
@@ -65,7 +65,7 @@ workflow jgi_metaASM {
         proj=proj,
         prefix=prefix,
         # start=stage.start, 
-        container=worflowmeta_container,
+        container=workflowmeta_container,
         fasta=create_agp.outcontigs,
         scaffold=create_agp.outscaffolds,
         agp=create_agp.outagp,
@@ -93,7 +93,7 @@ workflow jgi_metaASM {
     #     samgz_name=basename(finish_asm.outcontigs),
     #     covstats_name=basename(finish_asm.outcontigs),
     #     asmstats_name=basename(finish_asm.outcontigs),
-    #     container = worflowmeta_container
+    #     container = workflowmeta_container
     # }
  
     output {


### PR DESCRIPTION
Added `stats.json` into the output for both short and long reads.
``` json
{
  "scaffolds": 0,
  "contigs": 0,
  "scaf_bp": 0,
  "contig_bp": 0,
  "gap_pct": 0,
  "scaf_N50": 0,
  "scaf_L50": 0,
  "ctg_N50": 0,
  "ctg_L50": 0,
  "scaf_N90": 0,
  "scaf_L90": 0,
  "ctg_N90": 0,
  "ctg_L90": 0,
  "scaf_logsum": 0,
  "scaf_powsum": 0,
  "ctg_logsum": 0,
  "ctg_powsum": 0,
  "asm_score": 0,
  "scaf_max": 0,
  "ctg_max": 0,
  "scaf_n_gt50K": 0,
  "scaf_l_gt50K": 0,
  "scaf_pct_gt50K": 0,
  "gc_avg": 0,
  "gc_std": 0
}
```

### JAWS tests:
Short Reads: 90754
Long Reads: 90653