### PR TITLE
Assembly Update GH node version

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Read version
         id: get_version


### PR DESCRIPTION
the only github action here is the version bump, which isn't triggered unless we actually bump the version